### PR TITLE
fix: exclude docs and tests from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,11 @@ setuptools.setup(
     author_email="googleapis-packages@google.com",
     license="Apache 2.0",
     url="https://github.com/googleapis/python-documentai",
-    packages=setuptools.PEP420PackageFinder.find(),
+    packages=[
+        package
+        for package in setuptools.PEP420PackageFinder.find()
+        if package.startswith("google")
+    ],
     namespace_packages=("google", "google.cloud"),
     platforms="Posix; MacOS X; Windows",
     include_package_data=True,


### PR DESCRIPTION
Only include packages that start with google in the published artifact