### PR TITLE
fix(deps): pin 'google-{api,cloud}-core', 'google-auth' to allow 2.x versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,10 @@ setuptools.setup(
     platforms="Posix; MacOS X; Windows",
     include_package_data=True,
     install_requires=(
-        "google-api-core[grpc] >= 1.26.0, <2.0.0dev",
+        # NOTE: Maintainers, please do not require google-api-core>=2.x.x
+        # Until this issue is closed
+        # https://github.com/googleapis/google-cloud-python/issues/10566
+        "google-api-core[grpc] >= 1.26.0, <3.0.0dev",
         "proto-plus >= 1.4.0",
         "packaging >= 14.3",
     ),


### PR DESCRIPTION
Expand pins on library dependencies in preparation for these dependencies taking a new major version. See https://github.com/googleapis/google-cloud-python/issues/10566.