### PR TITLE
chore: add default_version to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,5 +10,6 @@
     "repo": "googleapis/python-binary-authorization",
     "distribution_name": "google-cloud-binary-authorization",
     "api_id": "binaryauthorization.googleapis.com",
-    "codeowner_team": "@googleapis/cicd"
-    }
+    "codeowner_team": "@googleapis/cicd",
+    "default_version": ""
+}

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,5 +11,5 @@
     "distribution_name": "google-cloud-binary-authorization",
     "api_id": "binaryauthorization.googleapis.com",
     "codeowner_team": "@googleapis/cicd",
-    "default_version": ""
+    "default_version": "v1"
 }


### PR DESCRIPTION
Set default_version to v1. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114