### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "binaryauthorization",
     "name_pretty": "Binary Authorization",
     "product_documentation": "https://cloud.google.com/binary-authorization",
-    "client_documentation": "https://googleapis.dev/python/binaryauthorization/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/binaryauthorization/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.