### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "binaryauthorization",
     "name_pretty": "Binary Authorization",
     "product_documentation": "https://cloud.google.com/binary-authorization",
-    "client_documentation": "https://googleapis.dev/python/binaryauthorization/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/binaryauthorization/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ policy control for images deployed to Kubernetes Engine clusters.
    :target: https://pypi.org/project/google-cloud-binary-authorization/
 
 .. _Binary Authorization API: https://cloud.google.com/binary-authorization
-.. _Client Library Documentation: https://googleapis.dev/python/binaryauthorization/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/binaryauthorization/latest
 .. _Product Documentation:  https://cloud.google.com/binary-authorization
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.